### PR TITLE
Changes to headerfile to work on esp8266 as well. 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=SparkFun Micro OLED Breakout for ESP8266
+name=SparkFun Micro OLED Breakout
 version=1.1.1
 author=SparkFun Electronics <techsupport@sparkfun.com>
-maintainer=Emil Varughese <emil01@gmail.com>
+maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the <a href="https://www.sparkfun.com/products/13003">SparkFun Micro OLED Breakout</a>.
 paragraph=Library for the Micro OLED Breakout, a monochrome, 0.66", 64x48 OLED display. Several basic functionlity examples included.  
 category=Display
-url=https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library
+url=https://github.com/sparkfun/SparkFun_Micro_OLED_Arduino_Library
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=SparkFun Micro OLED Breakout
+name=SparkFun Micro OLED Breakout for ESP8266
 version=1.1.1
 author=SparkFun Electronics <techsupport@sparkfun.com>
-maintainer=SparkFun Electronics <sparkfun.com>
+maintainer=Emil Varughese <emil01@gmail.com>
 sentence=Library for the <a href="https://www.sparkfun.com/products/13003">SparkFun Micro OLED Breakout</a>.
 paragraph=Library for the Micro OLED Breakout, a monochrome, 0.66", 64x48 OLED display. Several basic functionlity examples included.  
 category=Display
-url=https://github.com/sparkfun/SparkFun_Micro_OLED_Arduino_Library
+url=https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library
 architectures=*

--- a/src/SFE_MicroOLED.cpp
+++ b/src/SFE_MicroOLED.cpp
@@ -6,6 +6,11 @@ Jim Lindblom @ SparkFun Electronics
 October 26, 2014
 https://github.com/sparkfun/Micro_OLED_Breakout/tree/master/Firmware/Arduino/libraries/SFE_MicroOLED
 
+Modified by:
+Emil Varughese @ Edwin Robotics Pvt. Ltd.
+July 27, 2015
+https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
+
 This file defines the hardware interface(s) for the Micro OLED Breakout. Those
 interfaces include SPI, I2C and a parallel bus.
 

--- a/src/SFE_MicroOLED.cpp
+++ b/src/SFE_MicroOLED.cpp
@@ -28,8 +28,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
-
-#include <avr/pgmspace.h>
+#include <Arduino.h>
+#ifdef __AVR__
+	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
+#endif
 #include <SFE_MicroOLED.h>
 
 // This fixed ugly GCC warning "only initialized variables can be placed into program memory area"

--- a/src/SFE_MicroOLED.h
+++ b/src/SFE_MicroOLED.h
@@ -34,7 +34,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdio.h>
 #include <Arduino.h>
-#include <avr/pgmspace.h>
+
+#ifdef __AVR__
+	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
+#endif
 
 #define swap(a, b) { uint8_t t = a; a = b; b = t; }
 

--- a/src/SFE_MicroOLED.h
+++ b/src/SFE_MicroOLED.h
@@ -6,6 +6,12 @@ Jim Lindblom @ SparkFun Electronics
 October 26, 2014
 https://github.com/sparkfun/Micro_OLED_Breakout/tree/master/Firmware/Arduino/libraries/SFE_MicroOLED
 
+Modified by:
+Emil Varughese @ Edwin Robotics Pvt. Ltd.
+July 27, 2015
+https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
+
+
 This file defines the hardware interface(s) for the Micro OLED Breakout. Those
 interfaces include SPI, I2C and a parallel bus.
 

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -6,6 +6,11 @@ Jim Lindblom @ SparkFun Electronics
 October 26, 2014
 https://github.com/sparkfun/Micro_OLED_Breakout/tree/master/Firmware/Arduino/libraries/SFE_MicroOLED
 
+Modified by:
+Emil Varughese @ Edwin Robotics Pvt. Ltd.
+July 27, 2015
+https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
+
 This file defines the hardware interface(s) for the Micro OLED Breakout. Those
 interfaces include SPI, I2C and a parallel bus.
 

--- a/src/util/7segment.h
+++ b/src/util/7segment.h
@@ -19,7 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef FONT7SEGMENT_H
 #define FONT7SEGMENT_H
 
-#include <avr/pgmspace.h>
+#ifdef __AVR__
+	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
+#endif
 
 static const unsigned char sevensegment [] PROGMEM = {
 	// first row defines - FONTWIDTH, FONTHEIGHT, ASCII START CHAR, TOTAL CHARACTERS, FONT MAP WIDTH HIGH, FONT MAP WIDTH LOW (2,56 meaning 256)

--- a/src/util/7segment.h
+++ b/src/util/7segment.h
@@ -15,6 +15,12 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Modified by:
+Emil Varughese @ Edwin Robotics Pvt. Ltd.
+July 27, 2015
+https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
+
 ******************************************************************************/
 #ifndef FONT7SEGMENT_H
 #define FONT7SEGMENT_H

--- a/src/util/font5x7.h
+++ b/src/util/font5x7.h
@@ -19,7 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef FONT5X7_H
 #define FONT5X7_H
 
-#include <avr/pgmspace.h>
+#ifdef __AVR__
+	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
+#endif
 
 // Standard ASCII 5x7 font
 static const unsigned char font5x7[] PROGMEM = {

--- a/src/util/font5x7.h
+++ b/src/util/font5x7.h
@@ -15,6 +15,12 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Modified by:
+Emil Varughese @ Edwin Robotics Pvt. Ltd.
+July 27, 2015
+https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
+
 ******************************************************************************/
 #ifndef FONT5X7_H
 #define FONT5X7_H

--- a/src/util/font8x16.h
+++ b/src/util/font8x16.h
@@ -19,7 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef FONT8X16_H
 #define FONT8X16_H
 
-#include <avr/pgmspace.h>
+#ifdef __AVR__
+	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
+#endif
 
 static const unsigned char font8x16[] PROGMEM = {
 	// first row defines - FONTWIDTH, FONTHEIGHT, ASCII START CHAR, TOTAL CHARACTERS, FONT MAP WIDTH HIGH, FONT MAP WIDTH LOW (2,56 meaning 256)

--- a/src/util/font8x16.h
+++ b/src/util/font8x16.h
@@ -15,6 +15,11 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Modified by:
+Emil Varughese @ Edwin Robotics Pvt. Ltd.
+July 27, 2015
+https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 ******************************************************************************/
 #ifndef FONT8X16_H
 #define FONT8X16_H

--- a/src/util/fontlargenumber.h
+++ b/src/util/fontlargenumber.h
@@ -15,6 +15,12 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Modified by:
+Emil Varughese @ Edwin Robotics Pvt. Ltd.
+July 27, 2015
+https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
+
 ******************************************************************************/
 #ifndef FONTLARGENUMBER_H
 #define FONTLARGENUMBER_H

--- a/src/util/fontlargenumber.h
+++ b/src/util/fontlargenumber.h
@@ -19,7 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef FONTLARGENUMBER_H
 #define FONTLARGENUMBER_H
 
-#include <avr/pgmspace.h>
+#ifdef __AVR__
+	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
+#endif
 
 static const unsigned char fontlargenumber[] PROGMEM = {
 	// first row defines - FONTWIDTH, FONTHEIGHT, ASCII START CHAR, TOTAL CHARACTERS, FONT MAP WIDTH HIGH, FONT MAP WIDTH LOW (2,56 meaning 256)


### PR DESCRIPTION
Modified the header files to work fine on the esp8266 as well. 

Changed:

```
#include <avr/pgmspace.h>
```

To: 

```
#ifdef __AVR__
    #include <avr/pgmspace.h>
#else
    #include <pgmspace.h>
#endif
```

Note: Tested the demo codes using i2c and haven't faced any issues. 
