### PR TITLE
Load <avr/pgmspace.h> for Teensy3

### DIFF
--- a/src/SFE_MicroOLED.cpp
+++ b/src/SFE_MicroOLED.cpp
@@ -34,7 +34,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 #include <Arduino.h>
-#ifdef __AVR__
+#if defined(__AVR__) || defined(__arm__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/SFE_MicroOLED.h
+++ b/src/SFE_MicroOLED.h
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <Arduino.h>
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(__arm__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/7segment.h
+++ b/src/util/7segment.h
@@ -25,7 +25,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONT7SEGMENT_H
 #define FONT7SEGMENT_H
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(__arm__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/font5x7.h
+++ b/src/util/font5x7.h
@@ -25,7 +25,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONT5X7_H
 #define FONT5X7_H
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(__arm__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/font8x16.h
+++ b/src/util/font8x16.h
@@ -24,7 +24,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONT8X16_H
 #define FONT8X16_H
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(__arm__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/fontlargeletter31x48.h
+++ b/src/util/fontlargeletter31x48.h
@@ -19,7 +19,11 @@ https://github.com/DaAwesomeP/SparkFun_Micro_OLED_Arduino_Library/
 
 #ifndef FONTLARGELETTER31X48_H
 #define FONTLARGELETTER31X48_H
-#include <avr/pgmspace.h>
+#if defined(__AVR__) || defined(__arm__)
+	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
+#endif
 static const unsigned char fontlargeletter31x48 [] PROGMEM = {
     // first row defines - FONTWIDTH, FONTHEIGHT, ASCII START CHAR, TOTAL CHARACTERS, FONT MAP WIDTH HIGH, FONT MAP WIDTH LOW (2,56 meaning 256)
     31,48,65,58,0,62,

--- a/src/util/fontlargenumber.h
+++ b/src/util/fontlargenumber.h
@@ -25,7 +25,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONTLARGENUMBER_H
 #define FONTLARGENUMBER_H
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(__arm__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>


### PR DESCRIPTION
The [Teensy3 core](https://github.com/PaulStoffregen/cores/blob/master/teensy3/avr/pgmspace.h) has `pgmspace.h` in the `avr` directory. Not sure if this would break other ARM-based Arduinos but it worked for a Teensy 3.2

[![Teensy 3.2](https://v.cdn.vine.co/r/thumbs/4528D46CC71267349724819025920_SW_WEBM_1445133930896_image.jpg?versionId=pZFiXT7GCj0H0M7frG_OY0rhKBDkIKAo)](https://vine.co/v/e9MJ70n2I2v/embed/simple)
