### PR TITLE
Add a library.json to register in PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,12 @@
+{
+    "name": "SparkFun Micro OLED Breakout",
+    "keywords": "display oled",
+    "description": "Library for the SparkFun Micro OLED Breakout",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/ataxexe/SparkFun_Micro_OLED_Arduino_Library.git"
+    },
+    "frameworks": "arduino",
+    "platforms": "*"
+}

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
     "repository":
     {
         "type": "git",
-        "url": "https://github.com/ataxexe/SparkFun_Micro_OLED_Arduino_Library.git"
+        "url": "https://github.com/sparkfun/SparkFun_Micro_OLED_Arduino_Library.git"
     },
     "frameworks": "arduino",
     "platforms": "*"


### PR DESCRIPTION
The `library.json` file allows registration of this lib in [PlatformIO](http://platformio.org/)
