### PR TITLE
Add Support for Arduino 101

### DIFF
--- a/src/SFE_MicroOLED.cpp
+++ b/src/SFE_MicroOLED.cpp
@@ -34,7 +34,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 #include <Arduino.h>
-#if defined(__AVR__) || defined(__arm__)
+#if defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/SFE_MicroOLED.h
+++ b/src/SFE_MicroOLED.h
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <Arduino.h>
 
-#if defined(__AVR__) || defined(__arm__)
+#if defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/7segment.h
+++ b/src/util/7segment.h
@@ -25,7 +25,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONT7SEGMENT_H
 #define FONT7SEGMENT_H
 
-#if defined(__AVR__) || defined(__arm__)
+#if defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/font5x7.h
+++ b/src/util/font5x7.h
@@ -25,7 +25,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONT5X7_H
 #define FONT5X7_H
 
-#if defined(__AVR__) || defined(__arm__)
+#if defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/font8x16.h
+++ b/src/util/font8x16.h
@@ -24,7 +24,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONT8X16_H
 #define FONT8X16_H
 
-#if defined(__AVR__) || defined(__arm__)
+#if defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/fontlargeletter31x48.h
+++ b/src/util/fontlargeletter31x48.h
@@ -19,7 +19,7 @@ https://github.com/DaAwesomeP/SparkFun_Micro_OLED_Arduino_Library/
 
 #ifndef FONTLARGELETTER31X48_H
 #define FONTLARGELETTER31X48_H
-#if defined(__AVR__) || defined(__arm__)
+#if defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>

--- a/src/util/fontlargenumber.h
+++ b/src/util/fontlargenumber.h
@@ -25,7 +25,7 @@ https://github.com/emil01/SparkFun_Micro_OLED_Arduino_Library/
 #ifndef FONTLARGENUMBER_H
 #define FONTLARGENUMBER_H
 
-#if defined(__AVR__) || defined(__arm__)
+#if defined(__AVR__) || defined(__arm__) || defined(__ARDUINO_ARC__)
 	#include <avr/pgmspace.h>
 #else
 	#include <pgmspace.h>


### PR DESCRIPTION
Add support for Arduino 101 by loading <avr/pgmspace.h> using the
__ARDUINO_ARC__ variable defined in the Arduino 101 platform
definition file.