### PR TITLE
Change swap def to swapOLED, to avoid problems with some platforms

### DIFF
--- a/src/SFE_MicroOLED.cpp
+++ b/src/SFE_MicroOLED.cpp
@@ -492,13 +492,13 @@ Draw line using color and mode from x0,y0 to x1,y1 of the screen buffer.
 void MicroOLED::line(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, uint8_t color, uint8_t mode) {
 	uint8_t steep = abs(y1 - y0) > abs(x1 - x0);
 	if (steep) {
-		swap(x0, y0);
-		swap(x1, y1);
+		swapOLED(x0, y0);
+		swapOLED(x1, y1);
 	}
 
 	if (x0 > x1) {
-		swap(x0, x1);
-		swap(y0, y1);
+		swapOLED(x0, x1);
+		swapOLED(y0, y1);
 	}
 
 	uint8_t dx, dy;

--- a/src/SFE_MicroOLED.h
+++ b/src/SFE_MicroOLED.h
@@ -47,7 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	#include <pgmspace.h>
 #endif
 
-#define swap(a, b) { uint8_t t = a; a = b; b = t; }
+#define swapOLED(a, b) { uint8_t t = a; a = b; b = t; }
 
 #define I2C_ADDRESS_SA0_0 0b0111100
 #define I2C_ADDRESS_SA0_1 0b0111101


### PR DESCRIPTION
ESP32 platform had problems to compile with the MicroOLED because it already have a swap function.
xtensa-esp32-elf/include/c++/5.2.0/bits/exception_ptr.h

The swapOLED worked fine on the ESP32 thing (cube test)