### PR TITLE
initialize Wire lib in I2C setup

### DIFF
--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -83,7 +83,8 @@ void MicroOLED::spiTransfer(byte data)
 **/
 void MicroOLED::i2cSetup()
 {
-
+	// Initialize Wire library (I2C)
+	Wire.begin();
 }
 
 /** \brief  Write a byte over I2C


### PR DESCRIPTION
I've add a line to initialize the Wire library during the I2C setup.
I've tested the code on an ESP8266 and **without** the init line the I2C protocol doesn't work.