### PR TITLE
Use _delay_ms instead of delay.

### DIFF
--- a/src/SFE_MicroOLED.cpp
+++ b/src/SFE_MicroOLED.cpp
@@ -283,9 +283,9 @@ void MicroOLED::beginCommon()
 	// Display reset routine
 	pinMode(rstPin, OUTPUT);	// Set RST pin as OUTPUT
 	digitalWrite(rstPin, HIGH); // Initially set RST HIGH
-	delay(5);					// VDD (3.3V) goes high at start, lets just chill for 5 ms
+	_delay_ms(5);					// VDD (3.3V) goes high at start, lets just chill for 5 ms
 	digitalWrite(rstPin, LOW);	// Bring RST low, reset the display
-	delay(10);					// wait 10ms
+	_delay_ms(10);					// wait 10ms
 	digitalWrite(rstPin, HIGH); // Set RST HIGH, bring out of reset
 
 	// Display Init sequence for 64x48 OLED module


### PR DESCRIPTION
Since the delays are constant expressions, there's no need to use the Arduino delay function over the avr-libc one, and this way it works even if the timers are repurposed so millis() doesn't work right.
