### PR TITLE
Increment version info in libray.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "SparkFun Micro OLED Breakout",
-    "version": "1.2.7",
+    "version": "1.3.0",
     "keywords": "display oled",
     "description": "Library for the SparkFun Micro OLED Breakout",
     "repository":


### PR DESCRIPTION
This equalizes the PlatformIO library information with the Arduino one's in `library.properties`. 

Without this change, the PlatformIO library registry will not pick up a new version -- https://platformio.org/lib/show/366/SparkFun%20Micro%20OLED%20Breakout is stuck at a version from a year ago.